### PR TITLE
fix fcaseopen buffer overflow

### DIFF
--- a/fcaseopen.c
+++ b/fcaseopen.c
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-// r must have strlen(path) + 2 bytes
+// r must have strlen(path) + 3 bytes
 static int casepath(char const *path, char *r)
 {
     size_t l = strlen(path);
@@ -87,7 +87,7 @@ FILE *fcaseopen(char const *path, char const *mode)
 #if !defined(_WIN32)
     if (!f)
     {
-        char *r = alloca(strlen(path) + 2);
+        char *r = alloca(strlen(path) + 3);
         if (casepath(path, r))
         {
             f = fopen(r, mode);
@@ -100,7 +100,7 @@ FILE *fcaseopen(char const *path, char const *mode)
 void casechdir(char const *path)
 {
 #if !defined(_WIN32)
-    char *r = alloca(strlen(path) + 2);
+    char *r = alloca(strlen(path) + 3);
     if (casepath(path, r))
     {
         chdir(r);


### PR DESCRIPTION
This pull request fixes https://github.com/OneSadCookie/fcaseopen/issues/2

fcaseopen actually requires three more bytes than strlen(path) not two as laid out in my issue

Thanks,
Aaron.